### PR TITLE
Generate firestore.indexes.json from schema.yaml

### DIFF
--- a/sample/schema.yaml
+++ b/sample/schema.yaml
@@ -89,3 +89,19 @@ models:
       - name: updatedAt
         type: DateTime
         isUpdatedAt: true
+
+indexes:
+  - collectionGroup: "User"
+    queryScope: "COLLECTION"
+    fields:
+      - fieldPath: "email"
+        order: "ASCENDING"
+      - fieldPath: "createdAt"
+        order: "DESCENDING"
+  - collectionGroup: "Post"
+    queryScope: "COLLECTION"
+    fields:
+      - fieldPath: "status"
+        order: "ASCENDING"
+      - fieldPath: "createdAt"
+        order: "DESCENDING"

--- a/src/__tests__/indexGenerator.test.ts
+++ b/src/__tests__/indexGenerator.test.ts
@@ -1,0 +1,64 @@
+import { parseSchema } from "../parseSchema";
+import { Schema } from "../interface";
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+describe('Index Generator', () => {
+    let parsedSchema: Schema;
+
+    beforeAll(async () => {
+        const schemaFilePath = path.resolve(__dirname, '../../sample/schema.yaml');
+        const schemaContent = fs.readFileSync(schemaFilePath, 'utf-8');
+        parsedSchema = await parseSchema(schemaContent);
+    });
+
+    it('should correctly parse index definitions from schema', () => {
+        expect(parsedSchema.indexes).toEqual([
+            {
+                collectionGroup: "User",
+                queryScope: "COLLECTION",
+                fields: [
+                    { fieldPath: "email", order: "ASCENDING" },
+                    { fieldPath: "createdAt", order: "DESCENDING" }
+                ]
+            },
+            {
+                collectionGroup: "Post",
+                queryScope: "COLLECTION",
+                fields: [
+                    { fieldPath: "status", order: "ASCENDING" },
+                    { fieldPath: "createdAt", order: "DESCENDING" }
+                ]
+            }
+        ]);
+    });
+
+    it('should generate firestore.indexes.json correctly', () => {
+        const indexesJson = {
+            indexes: parsedSchema.indexes,
+            fieldOverrides: []
+        };
+        const expectedIndexesJson = {
+            indexes: [
+                {
+                    collectionGroup: "User",
+                    queryScope: "COLLECTION",
+                    fields: [
+                        { fieldPath: "email", order: "ASCENDING" },
+                        { fieldPath: "createdAt", order: "DESCENDING" }
+                    ]
+                },
+                {
+                    collectionGroup: "Post",
+                    queryScope: "COLLECTION",
+                    fields: [
+                        { fieldPath: "status", order: "ASCENDING" },
+                        { fieldPath: "createdAt", order: "DESCENDING" }
+                    ]
+                }
+            ],
+            fieldOverrides: []
+        };
+        expect(indexesJson).toEqual(expectedIndexesJson);
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,8 +78,18 @@ async function main() {
         const ormCodePath = path.join(outputDirPath, 'orm.ts');
         fs.writeFileSync(ormCodePath, ormCode);
         console.log(`ORM code generated at "${ormCodePath}"`);
+
+        // Indexes JSONの生成
+        console.log('Generating Firestore indexes JSON...');
+        const indexesJson = {
+            indexes: parsedSchema.indexes,
+            fieldOverrides: []
+        };
+        const indexesJsonPath = path.join(outputDirPath, 'firestore.indexes.json');
+        fs.writeFileSync(indexesJsonPath, JSON.stringify(indexesJson, null, 2));
+        console.log(`Firestore indexes JSON generated at "${indexesJsonPath}"`);
     } catch (error) {
-        console.error('Error generating Firestore rules or ORM code:', error);
+        console.error('Error generating Firestore rules, ORM code, or indexes JSON:', error);
         process.exit(1);
     }
 }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,4 +1,3 @@
-// インターフェースの定義
 export interface EnumDefinition {
     [enumName: string]: string[];
 }
@@ -22,7 +21,17 @@ export interface ModelDefinition {
     fields: FieldDefinition[];
 }
 
+export interface IndexDefinition {
+    collectionGroup: string;
+    queryScope: string;
+    fields: {
+        fieldPath: string;
+        order: string;
+    }[];
+}
+
 export interface Schema {
     enums: EnumDefinition;
     models: ModelDefinition[];
+    indexes?: IndexDefinition[];
 }

--- a/src/parseSchema.ts
+++ b/src/parseSchema.ts
@@ -40,8 +40,11 @@ export async function parseSchema(schema: string): Promise<Schema> {
         };
     });
 
+    const indexes = parsed.indexes || [];
+
     return {
         enums,
         models,
+        indexes,
     };
 }


### PR DESCRIPTION
Fixes #17

Add functionality to generate `firestore.indexes.json` from `sample/schema.yaml`.

* **sample/schema.yaml**
  - Add index definitions for "User" and "Post" collections with fields and order.

* **src/parseSchema.ts**
  - Update schema parsing logic to handle index definitions.

* **src/index.ts**
  - Add logic to generate `firestore.indexes.json` based on parsed index definitions.

* **src/__tests__/indexGenerator.test.ts**
  - Add tests to verify index generation functionality.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yuki-koma2/firestore-tools/pull/18?shareId=da6b9f8b-feb8-4f56-a10b-30f4b9999b64).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ユーザーおよび投稿モデルのための新しいインデックスが追加され、クエリ能力が向上しました。
  - FirestoreインデックスのJSONを生成する機能が追加され、`firestore.indexes.json`ファイルに書き込まれます。

- **テスト**
  - インデックス生成機能のための新しいテストスイートが追加され、インデックス定義の正確性を検証します。

- **ドキュメント**
  - スキーマ解析関数がインデックスを処理するように更新され、返されるオブジェクトにインデックスが含まれます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->